### PR TITLE
tests: add test_spectral_flux target so SpectralFlux sources are incl…

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,3 +107,14 @@ endif()
 
 # GUI wallpaper tests removed - wxWidgets GUI has been deprecated and deleted
 # The GUI is now implemented in Unreal Engine (TripSitter standalone app)
+    # Spectral flux tests
+    add_executable(test_spectral_flux
+        catch_main.cpp
+        test_spectral_flux.cpp
+        ../src/audio/SpectralFlux.cpp
+    )
+
+    target_include_directories(test_spectral_flux PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_link_libraries(test_spectral_flux PRIVATE Catch2::Catch2)
+    add_test(NAME spectral_flux COMMAND test_spectral_flux)
+    set_tests_properties(spectral_flux PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")


### PR DESCRIPTION
…uded

### Summary
Please describe the change and why it is needed.

### Checklist
- [ ] I have added/updated tests
- [ ] I have updated documentation

### GPU / CUDA / ONNX Note
If your PR touches GPU code (CUDA, ONNX runtime, device providers, .cu files, or environment flags like `BEATSYNC_ONNX_USE_CUDA`):
- Add the label **`test-cuda`** to the PR so the gated CUDA integration workflow runs on a GPU-enabled runner.
- Optionally mention which GPU/drivers were used for testing and any special setup.

Thanks!
<details>
<summary>Optional: PR Metadata (Type, Related Issues, Breaking Changes)</summary>

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Related Issues
Link any related issues (optional). For example:
- Closes #123

### Breaking Changes
If this PR introduces breaking changes, briefly document migration steps or upgrade guidance here. If not applicable, leave blank.

</details>